### PR TITLE
Changes to reduce redundancies in error messages

### DIFF
--- a/R/checkColumnPrefix.R
+++ b/R/checkColumnPrefix.R
@@ -52,6 +52,6 @@ checkColumnPrefix <- function(measure_alias, measure_type, nda_required_variable
       )
     })
   }, error = function(e) {
-    message(e$message)
+    #message(e$message)
   })
 }

--- a/R/checkInterviewAge.R
+++ b/R/checkInterviewAge.R
@@ -64,7 +64,7 @@ checkInterviewAge <- function(measure_alias) {
       )
     })
   }, error = function(e) {
-    message("The following subjects have out of range ages:",rows_not_meeting_condition, e$message)
+    #message("The following subjects have out of range ages:",rows_not_meeting_condition, e$message)
   })
   }
 }

--- a/R/checkQualtricsDuplicates.R
+++ b/R/checkQualtricsDuplicates.R
@@ -59,7 +59,6 @@ checkQualtricsDuplicates <- function(measure_alias, measure_type, verbose = TRUE
             }, error = function(e) {
               duplicates_summary <- toString(base::unique(df_duplicates[[identifier]]))
               message(paste("Error in testing for duplicates in '", measure_alias, "': ", e$message,
-                            "\nOffending IDs: ", duplicates_summary,
                             "\nDetails exported to ", paste0("./tmp/",duplicate_extract,".csv")))
             })
 

--- a/R/cleanDataFrameExists.R
+++ b/R/cleanDataFrameExists.R
@@ -35,7 +35,7 @@ cleanDataFrameExists <- function(measure_alias, measure_type) {
     })
 
   }, error = function(e) {
-    message("The script did not create a'", output_df_name, "' dataframe.", e$message)
+    #message("The script did not create a'", output_df_name, "' dataframe.", e$message)
   })
 
 }

--- a/R/ndaRequiredVariablesExist.R
+++ b/R/ndaRequiredVariablesExist.R
@@ -60,7 +60,7 @@ ndaRequiredVariablesExist <- function(measure_alias, measure_type, nda_required_
                             info = paste("SCRIPT ERROR: All NDA required variables are not present in '", measure_alias, " please make sure the following variable is present in the clean df: '", missing_vars, "."))
     })
   }, error = function(e) {
-    message("All NDA required variables are not present in '", measure_alias, " please make sure the following variable is present in the clean df: '", missing_vars, ".", e$message)
+    #message("All NDA required variables are not present in '", measure_alias, " please make sure the following variable is present in the clean df: '", missing_vars, ".", e$message)
   })
 
 }


### PR DESCRIPTION
Removed redundant error messages for functions within testSuite within clean(). Detailed descriptions of wrong input or error still present but not printed as part of trycatch.